### PR TITLE
fix: disable CDX-AG-002 agnix rule — 'Token efficiency' false positive

### DIFF
--- a/.agnix.toml
+++ b/.agnix.toml
@@ -15,6 +15,7 @@ disabled_rules = [
     "CC-SK-017",   # Intentional - version is a client-specific frontmatter field
     "XP-003",      # Intentional - lib/cross-platform/RESEARCH.md documents all platform paths
     "CC-MEM-004",  # npm validate referenced in auto-generated CLAUDE.md (agent-core template issue)
+    "CDX-AG-002",  # False positive - "Token efficiency" in AGENTS.md is not a secret
 ]
 
 [tool_versions]


### PR DESCRIPTION
Agnix CI fails on main with `CDX-AG-002: Potential secret detected in AGENTS.md`. The trigger is the text 'Token efficiency' which is not a secret — it's an ecosystem-wide boilerplate instruction from agent-core sync.

This adds CDX-AG-002 to disabled_rules with a comment explaining the false positive, matching the pattern already used in agent-sh/agentsys.