### PR TITLE
docs(release-agent): add Repo-Intel Data dependency section

### DIFF
--- a/agents/release-agent.md
+++ b/agents/release-agent.md
@@ -279,3 +279,13 @@ Output the release summary:
 | Tag already exists | `[ERROR] Tag {tag} already exists` |
 | Publish failed | `[WARN] Release created but publish failed: {error}` |
 | Tool not installed | `[ERROR] Release tool {tool} not installed. Install with: {install command}` |
+
+
+## Repo-Intel Data
+
+**Needs:** `<stateDir>/repo-intel.json` (in `.claude/`, `.opencode/`, or `.codex/`).
+
+**Missing?** Ask the user via `AskUserQuestion` whether to run `/repo-intel init` (~10-30s, scans git history). On decline, proceed without the data - this agent degrades gracefully.
+
+**Binary:** `agent-analyzer` auto-downloads to `~/.agent-sh/bin/` from `agent-sh/agent-analyzer` GitHub releases (~10 MB) on first use. The `lib/agentsys` resolver locates the agentsys install (CC marketplace clone, npm global, or sibling repo) - users see a clear error message if neither agentsys nor the binary can be found.
+

--- a/agents/release-agent.md
+++ b/agents/release-agent.md
@@ -57,6 +57,23 @@ Parse from `$ARGUMENTS`:
 
 Check if a repo-intel map is available and log informational health data. This step is purely informational - never block or abort a release based on health data.
 
+### What you're querying and why
+
+You're calling two `repoIntel.queries` functions on the cached `repo-intel.json`:
+
+- **`health(cwd)`** - repository-wide pulse. Returns `{ active, busFactor, commitFrequency, aiRatio }`:
+  - `busFactor` (integer): how many people you'd need to lose before knowledge of the codebase becomes critical. **`busFactor === 1` = single-contributor risk** (one person knows everything). 2-3 = small team. >5 = healthy spread.
+  - `aiRatio` (0..1): fraction of commits attributed to AI tools. High values (>0.6) on a release branch = consider whether a human spot-check happened.
+  - `commitFrequency` (commits/day): a near-zero value before a release means little recent activity to validate.
+  - `active` (bool): false = no commits in the last 30 days, surface as a stalled-repo warning.
+- **`bugspots(cwd, { limit: 5 })`** - the five files where the largest fraction of recent commits were bug fixes. Returns `Array<{ path, bugFixRate, totalChanges, bugFixes, lastBugFix }>`:
+  - `bugFixRate` (0..1): commits-fixing-bugs / total-commits on this file. **>0.5 means the file is fragile** - more than half of its recent change history is fixing prior bugs. Worth flagging in release notes / inviting an extra reviewer.
+  - `totalChanges` and `bugFixes` are the raw counters that give the rate context (a 0.6 rate over 5 commits is noisy; over 50 commits it's a real pattern).
+
+If neither signal flags anything, the repo is releasable without callouts. If either does, surface the warnings - they don't block release, they inform it.
+
+### Steps
+
 1. Detect the state directory by checking which exists: `.claude/`, `.opencode/`, `.codex/` (in that order)
 2. Check if `<stateDir>/repo-intel.json` exists
 3. If the map file does NOT exist, skip this step silently and proceed to Phase 1
@@ -67,19 +84,17 @@ const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
 if (!pluginRoot) throw new Error('CLAUDE_PLUGIN_ROOT not set');
 const { repoIntel } = require(`${pluginRoot}/lib/agentsys`).get();
 if (!repoIntel) throw new Error('agentsys is older than v5.8.6 (typed repo-intel queries unavailable) - run `/plugin marketplace update` and retry');
-const health = repoIntel.queries.health(cwd);
-const bugspots = repoIntel.queries.bugspots(cwd, { limit: 5 });
+const health = repoIntel.queries.health(cwd);            // pulse: busFactor, aiRatio, etc.
+const bugspots = repoIntel.queries.bugspots(cwd, { limit: 5 });  // top 5 fragile files
 ```
 
 5. Log the health summary:
    - `[INFO] Repo health: busFactor={busFactor}, aiRatio={aiRatio}` (from health query)
    - For each bugspot with `bugFixRate > 0.5`: `[WARN] Top bugspot: {path} (bugFixRate={bugFixRate})`
    - If no bugspots exceed the threshold, no warning is logged
+   - Add `[WARN] Single-contributor risk` if `health.busFactor === 1`
 
 6. If the query fails (binary not available, map corrupt, etc.), log `[INFO] Repo health check skipped (query failed)` and continue
-
-Health query returns: `{active: boolean, busFactor: number, commitFrequency: number, aiRatio: number}`
-Bugspots query returns: `Array<{path: string, bugFixRate: number, totalChanges: number, bugFixes: number, lastBugFix: string|null}>`
 
 ## Phase 1: Discovery
 

--- a/agents/release-agent.md
+++ b/agents/release-agent.md
@@ -283,9 +283,9 @@ Output the release summary:
 
 ## Repo-Intel Data
 
-**Needs:** `<stateDir>/repo-intel.json` (in `.claude/`, `.opencode/`, or `.codex/`).
+**Expected:** the orchestrator (the command that spawned this agent) has already checked `<stateDir>/repo-intel.json` and either pre-fetched the data into your context or skipped (user declined to generate). **Do not call `AskUserQuestion` here** - subagents cannot interact with the user.
 
-**Missing?** Ask the user via `AskUserQuestion` whether to run `/repo-intel init` (~10-30s, scans git history). On decline, proceed without the data - this agent degrades gracefully.
+**If the pre-fetched data is empty**, proceed with the available context. The orchestrator has already made the decision on the user's behalf.
 
-**Binary:** `agent-analyzer` auto-downloads to `~/.agent-sh/bin/` from `agent-sh/agent-analyzer` GitHub releases (~10 MB) on first use. The `lib/agentsys` resolver locates the agentsys install (CC marketplace clone, npm global, or sibling repo) - users see a clear error message if neither agentsys nor the binary can be found.
+**Binary:** `agent-analyzer` auto-downloads to `~/.agent-sh/bin/` from `agent-sh/agent-analyzer` GitHub releases (~10 MB) on first use. The `lib/agentsys` resolver locates the agentsys install (CC marketplace clone, npm global, or sibling repo).
 


### PR DESCRIPTION
Adds a uniform 'Repo-Intel Data' callout to release-agent.md so the agent knows: (1) what data it needs (`<stateDir>/repo-intel.json`), (2) to ask the user via `AskUserQuestion` before triggering `/repo-intel init`, (3) where the binary auto-downloads from + to (`agent-sh/agent-analyzer` GH releases → `~/.agent-sh/bin/`).

Same wording is being added to the other 8 consumer plugins as part of the resolver fan-out (PRs deslop#43, sync-docs#21, drift-detect#22, audit-project#18, next-task#28, enhance#19, onboard#13, can-i-help#14).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adds guidance on optional repo-intel inputs and how to obtain them; no runtime behavior is modified.
> 
> **Overview**
> Adds a new **Repo-Intel Data** section to `agents/release-agent.md` documenting the optional dependency on `<stateDir>/repo-intel.json`, instructing the agent to prompt via `AskUserQuestion` before running `/repo-intel init`, and noting how the `agent-analyzer` binary is auto-downloaded and resolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ccb52d187c92e006b7f8b6e3113e34b5da667b6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->