### PR TITLE
chore: sync core lib and CLAUDE.md from agent-core

### DIFF
--- a/lib/cross-platform/index.js
+++ b/lib/cross-platform/index.js
@@ -303,15 +303,21 @@ function formatSection(title, content) {
  */
 
 /**
- * Truncate text to limit with ellipsis
+ * Truncate text to limit with ellipsis.
+ *
+ * Slices on Unicode code points (not UTF-16 code units) so multi-byte
+ * chars like emoji never end up as orphan surrogates. Non-positive
+ * maxLength returns the original string unchanged.
  *
  * @param {string} text - Text to truncate
- * @param {number} maxLength - Maximum length
+ * @param {number} maxLength - Maximum length (in code points)
  * @returns {string} Truncated text
  */
 function truncate(text, maxLength) {
-  if (text.length <= maxLength) return text;
-  return text.substring(0, maxLength - 3) + '...';
+  if (maxLength <= 0) return text;
+  const codePoints = [...text];
+  if (codePoints.length <= maxLength) return text;
+  return codePoints.slice(0, maxLength - 3).join('') + '...';
 }
 
 /**


### PR DESCRIPTION
Automated sync of lib/ and CLAUDE.md from [agent-core](https://github.com/agent-sh/agent-core).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk utility change, but it alters truncation behavior (code points vs UTF-16) which may slightly change output length and edge-case handling.
> 
> **Overview**
> Updates `truncate()` in `lib/cross-platform/index.js` to truncate by **Unicode code points** (avoiding broken surrogate pairs like emoji) and to treat non-positive `maxLength` as a no-op.
> 
> Also expands the JSDoc to clarify the new semantics and that `maxLength` is measured in code points.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 769c50ee22f534bda9aaef3e93fcc7102840d913. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->